### PR TITLE
Filter out None join files, from no end or start

### DIFF
--- a/vidcutter/libs/videoservice.py
+++ b/vidcutter/libs/videoservice.py
@@ -437,6 +437,7 @@ class VideoService(QObject):
             self.smartcut_jobs[index].files.get('middle'),
             self.smartcut_jobs[index].files.get('end')
         ]
+        joinlist = list(filter(None, joinlist))
         if self.isMPEGcodec(joinlist[1]):
             self.logger.info('smartcut files are MPEG based so join via MPEG-TS')
             final_join = self.mpegtsJoin(joinlist, self.smartcut_jobs[index].output, None)


### PR DESCRIPTION
Filter out None join files, from no end or start used when doing smart cut because there is a keyframe there. Otherwise this causes errors.
I am fairly sure this is one of the causes for #280 (at least it was for me).
This error later on causes an exception because the None is given to some os.path.* function